### PR TITLE
Update metro-window.md

### DIFF
--- a/controls/metro-window.md
+++ b/controls/metro-window.md
@@ -67,7 +67,8 @@ The `MetroWindow` can have...
                       Height="200"
                       Width="600"
 
-                      EnableDWMDropShadow="True"
+                      BorderThickness="0" 
+                      GlowBrush="Black"
                       ResizeMode="CanResizeWithGrip"
 
                       WindowTransitionsEnabled="False"


### PR DESCRIPTION
Property 'MahApps.Metro.Controls.MEtroWindow.EnableDWMDropShadow' is obsolete: "This property will be deleted in the next release. You should use BorderThickness="0" and a GlowBrush="Black" to get a drop shadow around the Window."